### PR TITLE
A block is made of 512 bytes

### DIFF
--- a/parse_raw.py
+++ b/parse_raw.py
@@ -28,7 +28,7 @@ for line in fileinput.input():
 			error_lines += 1
 			zeroLine()
 		else:
-			for i in range(0,512,2):
+			for i in range(0,1024,2):
 				output.write( chr( int (line[i:i+2], 16 ) ) )
 				normal_lines += 1
 


### PR DESCRIPTION
parse_raw.py is only reading 256 bytes
Because on the arduino side, hex values are printed as text.
So each byte from the SD card result in 2 bytes on the serial interface. As a result 512 bytes from the SD card became 1024 bytes.